### PR TITLE
tech(registry): Use Identifier object

### DIFF
--- a/Sources/CohesionKit/Identifier.swift
+++ b/Sources/CohesionKit/Identifier.swift
@@ -2,16 +2,24 @@
 struct Identifier: Hashable, Sendable, ExpressibleByStringLiteral {
   let identifier: String
 
-  init(identifier: String) {
+  init(_ identifier: String) {
     self.identifier = identifier
   }
 
   init(stringLiteral value: StringLiteralType) {
-    self.init(identifier: value)
+    self.init(value)
   }
 
-  /// Generates an identifier for a node
-  init<T>(node: EntityNode<T>) {
-    self.init(identifier: "\(T.self)-\(node.hashValue)")
+  /// Generates an identifier for type T with key as key
+  init<T>(for type: T.Type, key: Any) {
+    self.init("\(T.self):\(key)")
+  }
+
+  init<T: Identifiable>(for object: T) {
+    self.init(for: T.self, key: object.id)
+  }
+
+  init<T>(for type: T.Type, key: AliasKey<T>) {
+    self.init("alias:\(T.self):\(key.name)")
   }
 }

--- a/Sources/CohesionKit/Identifier.swift
+++ b/Sources/CohesionKit/Identifier.swift
@@ -1,0 +1,17 @@
+/// a unique identifier to observe an object
+struct Identifier: Hashable, Sendable, ExpressibleByStringLiteral {
+  let identifier: String
+
+  init(identifier: String) {
+    self.identifier = identifier
+  }
+
+  init(stringLiteral value: StringLiteralType) {
+    self.init(identifier: value)
+  }
+
+  /// Generates an identifier for a node
+  init<T>(node: EntityNode<T>) {
+    self.init(identifier: "\(T.self)-\(node.hashValue)")
+  }
+}

--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -15,7 +15,7 @@ class ObserverRegistry {
     }
 
     func addObserver<T>(node: EntityNode<T>, initial: Bool = false, onChange: @escaping (T) -> Void) -> Subscription {
-      addObserver(node: node, identifier: Identifier(node: node), initial: initial, onChange: onChange)
+      addObserver(node: node, identifier: node.id, initial: initial, onChange: onChange)
     }
 
     /// register an observer to observe changes on an entity node. Everytime `ObserverRegistry` is notified about changes
@@ -56,7 +56,7 @@ class ObserverRegistry {
           }
         }
 
-      let subscriptions = nodes.map { node in subscribeHandler(handler, for: node, identifier: Identifier(node: node)) }
+      let subscriptions = nodes.map { node in subscribeHandler(handler, for: node, identifier: node.id) }
 
         return Subscription {
             subscriptions.forEach { $0.unsubscribe() }
@@ -65,7 +65,7 @@ class ObserverRegistry {
 
     /// Mark a node as changed. Observers won't be notified of the change until ``postChanges`` is called
     func enqueueChange<T>(for node: EntityNode<T>) {
-      enqueueChange(for: node, identifier: Identifier(node: node))
+      enqueueChange(for: node, identifier: node.id)
     }
 
     func enqueueChange<T>(for node: EntityNode<T>, identifier: Identifier) {
@@ -73,7 +73,7 @@ class ObserverRegistry {
     }
 
     func hasPendingChange<T>(for node: EntityNode<T>) -> Bool {
-      hasPendingChange(for: Identifier(node: node))
+      hasPendingChange(for: node.id)
     }
 
     func hasPendingChange(for identifier: Identifier) -> Bool {

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -1,17 +1,17 @@
 /// Keep a strong reference on each aliased node
-typealias AliasStorage = [String: any AnyEntityNode]
+typealias AliasStorage = [Identifier: any AnyEntityNode]
 
 extension AliasStorage {
     subscript<T>(_ aliasKey: AliasKey<T>) -> EntityNode<AliasContainer<T>>? {
-        get { self[buildKey(for: T.self, key: aliasKey)] as? EntityNode<AliasContainer<T>> }
-        set { self[buildKey(for: T.self, key: aliasKey)] = newValue }
+        get { self[Identifier(for: T.self, key: aliasKey)] as? EntityNode<AliasContainer<T>> }
+        set { self[Identifier(for: T.self, key: aliasKey)] = newValue }
     }
 
     subscript<T>(safe key: AliasKey<T>) -> EntityNode<AliasContainer<T>> {
-        mutating get {
-            let storeKey = buildKey(for: T.self, key: key)
-            return self[key: key, default: EntityNode(AliasContainer(key: key), key: storeKey, modifiedAt: nil)]
-        }
+      mutating get {
+        let storeKey = Identifier(for: T.self, key: key)
+        return self[key: key, default: EntityNode(AliasContainer(key: key), id: storeKey, modifiedAt: nil)]
+      }
     }
 
     subscript<T>(key key: AliasKey<T>, default defaultValue: @autoclosure () -> EntityNode<AliasContainer<T>>)
@@ -27,9 +27,5 @@ extension AliasStorage {
 
             return node
         }
-    }
-
-    private func buildKey<T>(for type: T.Type, key: AliasKey<T>) -> String {
-        "\(type):\(key.name)"
     }
 }

--- a/Sources/CohesionKit/Storage/EntitiesStorage.swift
+++ b/Sources/CohesionKit/Storage/EntitiesStorage.swift
@@ -5,8 +5,8 @@ import Foundation
 /// Storage keeps weak references to objects.
 //// This allows to release entities automatically if no one is using them anymore (freeing memory space)
 struct EntitiesStorage {
-    /// the storage indexer. Stored content is [String: Weak<EntityNode<Object>>]
-    private typealias Storage = [String: AnyWeak]
+    /// the storage indexer. Stored content is [Identifier: Weak<EntityNode<Object>>]
+    private typealias Storage = [Identifier: AnyWeak]
 
     private var indexes: Storage = [:]
 
@@ -15,17 +15,13 @@ struct EntitiesStorage {
     }
 
     subscript<T: Identifiable>(_ type: T.Type, id id: T.ID) -> EntityNode<T>? {
-        get { (indexes[key(for: T.self, id: id)] as? Weak<EntityNode<T>>)?.value }
-        set { indexes[key(for: T.self, id: id)] = Weak(value: newValue) }
+      get { (indexes[Identifier(for: T.self, key: id)] as? Weak<EntityNode<T>>)?.value }
+      set { indexes[Identifier(for: T.self, key: id)] = Weak(value: newValue) }
     }
 
-    subscript(_ key: String) -> AnyWeak? {
-        get { indexes[key] }
-        set { indexes[key] = newValue }
-    }
-
-    private func key<T>(for type: T.Type, id: Any) -> String {
-        "\(type)-\(id)"
+    subscript(_ index: Identifier) -> AnyWeak? {
+        get { indexes[index] }
+        set { indexes[index] = newValue }
     }
 }
 

--- a/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
+++ b/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
@@ -73,7 +73,7 @@ class EntityNodeTests: XCTestCase {
 
         node.observeChild(childNode, for: \.singleNode)
 
-        XCTAssertTrue(childNode.metadata.parentsRefs.contains(node.storageKey))
+        XCTAssertTrue(childNode.metadata.parentsRefs.contains(node.id))
     }
 
     func test_observeChild_childrenMetadataIsUpdated() {
@@ -81,7 +81,7 @@ class EntityNodeTests: XCTestCase {
 
         node.observeChild(childNode, for: \.singleNode)
 
-        XCTAssertTrue(node.metadata.childrenRefs.keys.contains(childNode.storageKey))
+        XCTAssertTrue(node.metadata.childrenRefs.keys.contains(childNode.id))
     }
 
     func test_updateEntityRelationship_childIsUpdated() throws {


### PR DESCRIPTION
## ⚽️ Description

Introduce a new `Identifier` object and use it across ObserverRegistry and Store.

## 🔨 Implementation details

- Replace ObjectKey by Identifier
- Replace String inside storages by Identifier